### PR TITLE
Issue21

### DIFF
--- a/solace/templates/solaceConfigMap.yaml
+++ b/solace/templates/solaceConfigMap.yaml
@@ -92,7 +92,7 @@ data:
           role_results=`{{ .Values.filepaths.configmap }}/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
                 -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
                 -v "/rpc-reply/rpc/show/redundancy/active-standby-role[text()]"`
-          case "`echo ${role_results} | xmllint -xpath "valueSearchResult" -`" in
+          case "`echo ${role_results} | xmllint -xpath "returnInfo/valueSearchResult" -`" in
             "\"Primary\"")
             role="primary"
             break
@@ -117,7 +117,7 @@ data:
           online_results=`{{ .Values.filepaths.configmap }}/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
               -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
               -v "/rpc-reply/rpc/show/redundancy/virtual-routers/${role}/status/activity[text()]"`
-          local_activity=`echo ${online_results} | xmllint -xpath "valueSearchResult" -`
+          local_activity=`echo ${online_results} | xmllint -xpath "returnInfo/valueSearchResult" -`
           echo "`date` INFO: ${APP}-Local activity state is: ${local_activity}"
           run_time=$((${count} * ${pause}))
           case "${local_activity}" in
@@ -154,7 +154,7 @@ data:
             online_results=`{{ .Values.filepaths.configmap }}/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
                 -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
                 -v "/rpc-reply/rpc/show/redundancy/virtual-routers/${role}/status/detail/priority-reported-by-mate/summary[text()]"`
-            mate_activity=`echo ${online_results} | xmllint -xpath "valueSearchResult" -`
+            mate_activity=`echo ${online_results} | xmllint -xpath "returnInfo/valueSearchResult" -`
             echo "`date` INFO: ${APP}-Mate activity state is: ${mate_activity}"
             run_time=$((${count} * ${pause}))
             case "${mate_activity}" in
@@ -225,7 +225,7 @@ data:
       role_results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
               -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><group/></redundancy></show></rpc>" \
               -c "/rpc-reply/rpc/show/redundancy/group-node/status[text() = \"Online\"]"`
-      if [ `echo ${role_results} |  xmllint -xpath "countSearchResult" -` -eq 3 ]; then
+      if [ `echo ${role_results} |  xmllint -xpath "returnInfo/countSearchResult" -` -eq 3 ]; then
         echo "`date` INFO: ${APP}-Monitor node is redundancy ready"
         exit 0
       else
@@ -269,7 +269,7 @@ data:
     online_results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
             -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
             -v "/rpc-reply/rpc/show/redundancy/virtual-routers/${config_role}/status/activity[text()]"`
-    local_activity=`echo ${online_results} | xmllint -xpath "valueSearchResult" -`
+    local_activity=`echo ${online_results} | xmllint -xpath "returnInfo/valueSearchResult" -`
     echo "`date` INFO: ${APP}-Local activity state is: ${local_activity}"
     case "${local_activity}" in
       "\"Local Active\"")
@@ -352,7 +352,7 @@ data:
                   ,url=${url} ,value_search=${value_search} ,Leftovers: $@" >&2
       if [[ ${url} = "" || ${name} = "" || ${password} = "" || ${query} = "" ]]; then
           echo "`date` ERROR: ${APP}-${script_name}: url, name, password and query are madatory fields" >&2
-          echo  '<errorInfo>missing parameter</errorInfo>'
+          echo  '<returnInfo><errorInfo>missing parameter</errorInfo></returnInfo>'
           exit 1
         fi
       query_response=`curl -sS -u ${name}:${password} ${url} -d "${query}"`
@@ -365,14 +365,14 @@ data:
 
       if [[ -z ${query_response_code} && ${query_response_code} != "ok" ]]; then
           echo "`date` ERROR: ${APP}-${script_name}: Query failed, bad return code -${query_response}-" >&2
-          echo  "<errorInfo>query failed -${query_response_code}-</errorInfo>"
+          echo  "<returnInfo><errorInfo>query failed -${query_response_code}-</errorInfo></returnInfo>"
           exit 1
       fi
       echo "`date` INFO: ${APP}-${script_name}: Query passed ${query_response_code}" >&2
       if [[ ! -z $value_search ]]; then
           value_result=`echo $query_response | xmllint -xpath "string($value_search)" -`
           echo "`date` INFO: ${APP}-${script_name}: Value search $value_search returned ${value_result}" >&2
-          echo  "<errorInfo></errorInfo><valueSearchResult>${value_result}</valueSearchResult>"
+          echo  "<returnInfo><errorInfo></errorInfo><valueSearchResult>${value_result}</valueSearchResult></returnInfo>"
           exit 0
       fi
       if [[ ! -z $count_search ]]; then
@@ -380,6 +380,6 @@ data:
           count_string=`echo $count_search | cut -d '"' -f 2`
           count_result=`echo ${count_line} | tr "><" "\n" | grep -c ${count_string}`
           echo -e "`date` INFO: ${APP}-${script_name}: \n\t count search: $count_search \n\t count_line: ${count_line} \n\t count_string: ${count_string} \n\t count_result: ${count_result}" >&2
-          echo  "<errorInfo></errorInfo><countSearchResult>${count_result}</countSearchResult>"
+          echo  "<returnInfo><errorInfo></errorInfo><countSearchResult>${count_result}</countSearchResult></returnInfo>"
           exit 0
       fi

--- a/solace/templates/solaceConfigMap.yaml
+++ b/solace/templates/solaceConfigMap.yaml
@@ -74,12 +74,6 @@ data:
       #!/bin/bash
 {{- if .Values.solace.redundancy }}
       APP=`basename "$0"`
-      # install jq if not installed yet
-      if ! [ -x "$(command -v jq)" ] ; then
-        wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-        chmod +x ./jq
-        sudo cp jq /usr/bin
-      fi
       # [TODO] KBARR not using correct method of finding ordinal until we bump min Kubernetes release above 1.8.1
       # https://github.com/kubernetes/kubernetes/issues/40651
       # node_ordinal=$(STATEFULSET_ORDINAL)
@@ -98,7 +92,7 @@ data:
           role_results=`{{ .Values.filepaths.configmap }}/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
                 -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
                 -v "/rpc-reply/rpc/show/redundancy/active-standby-role[text()]"`
-          case "`echo ${role_results} | jq '.valueSearchResult' -`" in
+          case "`echo ${role_results} | xmllint -xpath "valueSearchResult" -`" in
             "\"Primary\"")
             role="primary"
             break
@@ -123,7 +117,7 @@ data:
           online_results=`{{ .Values.filepaths.configmap }}/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
               -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
               -v "/rpc-reply/rpc/show/redundancy/virtual-routers/${role}/status/activity[text()]"`
-          local_activity=`echo ${online_results} | jq '.valueSearchResult' -`
+          local_activity=`echo ${online_results} | xmllint -xpath "valueSearchResult" -`
           echo "`date` INFO: ${APP}-Local activity state is: ${local_activity}"
           run_time=$((${count} * ${pause}))
           case "${local_activity}" in
@@ -160,7 +154,7 @@ data:
             online_results=`{{ .Values.filepaths.configmap }}/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
                 -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
                 -v "/rpc-reply/rpc/show/redundancy/virtual-routers/${role}/status/detail/priority-reported-by-mate/summary[text()]"`
-            mate_activity=`echo ${online_results} | jq '.valueSearchResult' -`
+            mate_activity=`echo ${online_results} | xmllint -xpath "valueSearchResult" -`
             echo "`date` INFO: ${APP}-Mate activity state is: ${mate_activity}"
             run_time=$((${count} * ${pause}))
             case "${mate_activity}" in
@@ -231,7 +225,7 @@ data:
       role_results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
               -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><group/></redundancy></show></rpc>" \
               -c "/rpc-reply/rpc/show/redundancy/group-node/status[text() = \"Online\"]"`
-      if [ `echo ${role_results} | jq '.countSearchResult' -` -eq 3 ]; then
+      if [ `echo ${role_results} |  xmllint -xpath "countSearchResult" -` -eq 3 ]; then
         echo "`date` INFO: ${APP}-Monitor node is redundancy ready"
         exit 0
       else
@@ -275,7 +269,7 @@ data:
     online_results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
             -q "<rpc semp-version='soltr/8_5VMR'><show><redundancy><detail/></redundancy></show></rpc>" \
             -v "/rpc-reply/rpc/show/redundancy/virtual-routers/${config_role}/status/activity[text()]"`
-    local_activity=`echo ${online_results} | jq '.valueSearchResult' -`
+    local_activity=`echo ${online_results} | xmllint -xpath "valueSearchResult" -`
     echo "`date` INFO: ${APP}-Local activity state is: ${local_activity}"
     case "${local_activity}" in
       "\"Local Active\"")
@@ -358,7 +352,7 @@ data:
                   ,url=${url} ,value_search=${value_search} ,Leftovers: $@" >&2
       if [[ ${url} = "" || ${name} = "" || ${password} = "" || ${query} = "" ]]; then
           echo "`date` ERROR: ${APP}-${script_name}: url, name, password and query are madatory fields" >&2
-          echo  '{"errorInfo":"missing parameter"}'
+          echo  '<errorInfo>missing parameter</errorInfo>'
           exit 1
         fi
       query_response=`curl -sS -u ${name}:${password} ${url} -d "${query}"`
@@ -371,14 +365,14 @@ data:
 
       if [[ -z ${query_response_code} && ${query_response_code} != "ok" ]]; then
           echo "`date` ERROR: ${APP}-${script_name}: Query failed, bad return code -${query_response}-" >&2
-          echo  "{\"errorInfo\":\"query failed -${query_response_code}-\"}"
+          echo  "<errorInfo>query failed -${query_response_code}-</errorInfo>"
           exit 1
       fi
       echo "`date` INFO: ${APP}-${script_name}: Query passed ${query_response_code}" >&2
       if [[ ! -z $value_search ]]; then
           value_result=`echo $query_response | xmllint -xpath "string($value_search)" -`
           echo "`date` INFO: ${APP}-${script_name}: Value search $value_search returned ${value_result}" >&2
-          echo  "{\"errorInfo\":\"\",\"valueSearchResult\":\"${value_result}\"}"
+          echo  "<errorInfo></errorInfo><valueSearchResult>${value_result}</valueSearchResult>"
           exit 0
       fi
       if [[ ! -z $count_search ]]; then
@@ -386,6 +380,6 @@ data:
           count_string=`echo $count_search | cut -d '"' -f 2`
           count_result=`echo ${count_line} | tr "><" "\n" | grep -c ${count_string}`
           echo -e "`date` INFO: ${APP}-${script_name}: \n\t count search: $count_search \n\t count_line: ${count_line} \n\t count_string: ${count_string} \n\t count_result: ${count_result}" >&2
-          echo  "{\"errorInfo\":\"\",\"countSearchResult\":${count_result}}"
+          echo  "<errorInfo></errorInfo><countSearchResult>${count_result}</countSearchResult>"
           exit 0
       fi


### PR DESCRIPTION
This PR removes the requirement for external dependency on json and thus  jq.  It instead internally passes xml results.  External customers that do not expose the Solace PubSub+ container to the internet have issues with this dependency as jq is not yet a standard Linux tool.  The use of xmllint to parse the result should be safe from a deployment perspective as it is also required for SEMPv1 parsing.  

I have not done exhaustive jq vs xmllint performance comparisons, but the difference does not seem too bad.  