### PR TITLE
Configure script, default ports improvements, documentation of deploying using generated templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,84 @@ Similar value-files can be defined extending above examples:
     * `prod100k`: up to 100,000 connections, minimum requirements: 8 CPU, 28 GB memory
     * `prod200k`: up to 200,000 connections, minimum requirements: 12 CPU, 56 GB memory
 
+## Alternative installation: generating templates for Kubernetes Kubectl tool
+
+This is for users not wishing to install Helm server-side Tiller on the Kubernetes cluster. This method will first generate installable Kubernetes templates, then the templates are installed using the Kubectl tool.
+
+### Step 1: Generate Kubernetes templates for Solace message broker deployment
+
+1) Clone the Solace Kubernetes quickstart git project
+
+```sh
+git clone https://github.com/SolaceProducts/solace-kubernetes-quickstart.git
+cd solace-kubernetes-quickstart # This directory will be referenced as <project-root>
+```
+
+2) [Download](https://github.com/helm/helm/releases/tag/v2.9.1 ) and install the Helm client locally.
+
+We will assume that it has been installed to the `<project-root>/bin` directory.
+
+3) Customize the Solace chart for your deployment
+
+The Solace chart includes raw Kubernetes templates and a "values.yaml" file to customize them when the templates are generated.
+
+The chart is located in the `solace` directory:
+
+`cd <project-root>/solace`
+
+a) Optionally replace the `<project-root>/solace/values.yaml` file with one of the prepared examples from the `<project-root>/solace/values-examples` directory. For details refer to https://github.com/SolaceProducts/solace-kubernetes-quickstart#other-message-broker-deployment-configurations
+
+b) Then edit `<project-root>/solace/values.yaml` and replace following parameters:
+
+SOLOS_CLOUD_PROVIDER: Current options are [gcp|aws] or leave it unchanged for unknown (note: this is to optimize volume provisioning for supported providers)
+SOLOS_IMAGE_REPO and SOLOS_IMAGE_TAG: use `solace/solace-pubsub-standard` and `latest` for the latest available version from DockerHub (https://hub.docker.com/r/solace/solace-pubsub-standard/tags/). For more options, refer to https://github.com/SolaceProducts/solace-kubernetes-quickstart#step-3-optional
+
+c) Configure the Solace management password for `admin` user in `<project-root>/solace/templates/secret.yaml`:
+
+SOLOS_ADMIN_PASSWORD: change it to the desired password. For password rules, refer to https://docs.solace.com/Configuring-and-Managing/Configuring-Internal-CLI-User-Accounts.htm#Changing-CLI-User-Passwords
+
+4) Generate the templates
+
+```sh
+cd <project-root>/solace
+# Create location for the generated templates
+mkdir generated-templates
+# In next command replace myrelease to the desired release name
+<project-root>/bin/helm template --name myrelease --values values.yaml --output-dir ./generated-templates .
+```
+
+The generated set of templates are now available in the `<project-root>/solace/generated-templates` directory.
+
+### Step 2: Deploy the templates on the target system
+
+Assumptions: `kubectl` is deployed and configured to point to your Kubernetes cluster
+
+1) Optionally copy the `generated-templates` directory with contents if this is on a different host
+
+2) Assign rights to current user to modify cluster-wide RBAC (required for creating clusterrole binding when deploying the Solace template podModRbac.yaml)
+
+Example:
+
+```sh
+# Get current user - GCP example. Returns e.g.: myname@example.org
+gcloud info | grep Account  
+# Assign rigths - replace user
+kubectl create clusterrolebinding myname-cluster-admin-binding \
+  --clusterrole=cluster-admin \
+  --user=myname@example.org
+```
+
+3) Initiate the deployment:
+
+`kubectl apply --recursive -f ./generated-templates/solace`
+
+Wait for the deployment to complete, which is then ready to use.
+
+4) To delete deployment, execute:
+
+`kubectl delete --recursive -f ./generated-templates/solace`
+
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## Purpose of this repository
 
-This repository explains how to install a Solace PubSub+ Software Message Broker in various configurations onto a Kubernetes cluster using the Helm tool. This guide is intended mainly for development and demo purposes. The recommended Solace PubSub+ Software Message Broker version is 9.0 or later.
+This repository explains how to install a Solace PubSub+ Software Message Broker in various configurations onto a Kubernetes cluster. We recommend using the Helm tool for convenience. An [alternative method](#alternative-installation-generating-templates-for-kubernetes-kubectl-tool) using generated templates is also provided.
+
+This guide is intended mainly for development and demo purposes. The recommended Solace PubSub+ Software Message Broker version is 9.0 or later.
 
 This document is applicable to any platform supporting Kubernetes, with specific hints on how to set up a simple single-node MiniKube deployment on a Unix-based machine. To view examples of other platforms see:
 
@@ -395,11 +397,13 @@ Similar value-files can be defined extending above examples:
 
 ## Alternative installation: generating templates for Kubernetes Kubectl tool
 
-This is for users not wishing to install Helm server-side Tiller on the Kubernetes cluster. This method will first generate installable Kubernetes templates, then the templates are installed using the Kubectl tool.
+This is for users not wishing to install the Helm server-side Tiller on the Kubernetes cluster.
+
+This method will first generate installable Kubernetes templates from this project's Helm charts, then the templates can be installed using the Kubectl tool.
 
 ### Step 1: Generate Kubernetes templates for Solace message broker deployment
 
-1) Clone the Solace Kubernetes quickstart git project
+1) Clone this project:
 
 ```sh
 git clone https://github.com/SolaceProducts/solace-kubernetes-quickstart.git
@@ -418,16 +422,17 @@ The chart is located in the `solace` directory:
 
 `cd <project-root>/solace`
 
-a) Optionally replace the `<project-root>/solace/values.yaml` file with one of the prepared examples from the `<project-root>/solace/values-examples` directory. For details refer to https://github.com/SolaceProducts/solace-kubernetes-quickstart#other-message-broker-deployment-configurations
+a) Optionally replace the `<project-root>/solace/values.yaml` file with one of the prepared examples from the `<project-root>/solace/values-examples` directory. For details refer to the [Other Deployment Configurations section](#other-message-broker-deployment-configurations ]) in this document.
 
 b) Then edit `<project-root>/solace/values.yaml` and replace following parameters:
 
 SOLOS_CLOUD_PROVIDER: Current options are [gcp|aws] or leave it unchanged for unknown (note: this is to optimize volume provisioning for supported providers)
-SOLOS_IMAGE_REPO and SOLOS_IMAGE_TAG: use `solace/solace-pubsub-standard` and `latest` for the latest available version from DockerHub (https://hub.docker.com/r/solace/solace-pubsub-standard/tags/). For more options, refer to https://github.com/SolaceProducts/solace-kubernetes-quickstart#step-3-optional
+<br/>
+SOLOS_IMAGE_REPO and SOLOS_IMAGE_TAG: use `solace/solace-pubsub-standard` and `latest` for the latest available [version from DockerHub](https://hub.docker.com/r/solace/solace-pubsub-standard/tags/ ). For more options, refer to the [Solace PubSub+ message broker docker image section](#step-3-optional) in this document. 
 
 c) Configure the Solace management password for `admin` user in `<project-root>/solace/templates/secret.yaml`:
 
-SOLOS_ADMIN_PASSWORD: change it to the desired password. For password rules, refer to https://docs.solace.com/Configuring-and-Managing/Configuring-Internal-CLI-User-Accounts.htm#Changing-CLI-User-Passwords
+SOLOS_ADMIN_PASSWORD: change it to the desired password, considering the [password rules](https://docs.solace.com/Configuring-and-Managing/Configuring-Internal-CLI-User-Accounts.htm#Changing-CLI-User-Passwords )
 
 4) Generate the templates
 

--- a/README.md
+++ b/README.md
@@ -422,17 +422,17 @@ The chart is located in the `solace` directory:
 
 `cd <project-root>/solace`
 
-a) Optionally replace the `<project-root>/solace/values.yaml` file with one of the prepared examples from the `<project-root>/solace/values-examples` directory. For details refer to the [Other Deployment Configurations section](#other-message-broker-deployment-configurations ]) in this document.
+a) Optionally replace the `<project-root>/solace/values.yaml` file with one of the prepared examples from the `<project-root>/solace/values-examples` directory. For details refer to the [Other Deployment Configurations section](#other-message-broker-deployment-configurations) in this document.
 
 b) Then edit `<project-root>/solace/values.yaml` and replace following parameters:
 
-SOLOS_CLOUD_PROVIDER: Current options are [gcp|aws] or leave it unchanged for unknown (note: this is to optimize volume provisioning for supported providers)
+SOLOS_CLOUD_PROVIDER: Current options are "gcp" or "aws" or leave it unchanged for unknown (note: specifying the provider will optimize volume provisioning for supported providers).
 <br/>
-SOLOS_IMAGE_REPO and SOLOS_IMAGE_TAG: use `solace/solace-pubsub-standard` and `latest` for the latest available [version from DockerHub](https://hub.docker.com/r/solace/solace-pubsub-standard/tags/ ). For more options, refer to the [Solace PubSub+ message broker docker image section](#step-3-optional) in this document. 
+SOLOS_IMAGE_REPO and SOLOS_IMAGE_TAG: use `solace/solace-pubsub-standard` and `latest` for the latest available or specify a [version from DockerHub](https://hub.docker.com/r/solace/solace-pubsub-standard/tags/ ). For more options, refer to the [Solace PubSub+ message broker docker image section](#step-3-optional) in this document. 
 
 c) Configure the Solace management password for `admin` user in `<project-root>/solace/templates/secret.yaml`:
 
-SOLOS_ADMIN_PASSWORD: change it to the desired password, considering the [password rules](https://docs.solace.com/Configuring-and-Managing/Configuring-Internal-CLI-User-Accounts.htm#Changing-CLI-User-Passwords )
+SOLOS_ADMIN_PASSWORD: change it to the desired password, considering the [password rules](https://docs.solace.com/Configuring-and-Managing/Configuring-Internal-CLI-User-Accounts.htm#Changing-CLI-User-Passwords ).
 
 4) Generate the templates
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Purpose of this repository
 
-This repository explains how to install a Solace PubSub+ Software Message Broker in various configurations onto a Kubernetes cluster. We recommend using the Helm tool for convenience. An [alternative method](#alternative-installation-generating-templates-for-kubernetes-kubectl-tool) using generated templates is also provided.
+This repository explains how to install a Solace PubSub+ Software Message Broker in various configurations onto a Kubernetes cluster. We recommend using the Helm tool for convenience, which will be described in the next sections. An [alternative method](#alternative-installation-generating-templates-for-kubernetes-kubectl-tool) using generated templates is also provided.
 
 This guide is intended mainly for development and demo purposes. The recommended Solace PubSub+ Software Message Broker version is 9.0 or later.
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ git clone https://github.com/SolaceProducts/solace-kubernetes-quickstart.git
 cd solace-kubernetes-quickstart/solace    # location of the solace Helm chart
 ```
 
-* Next, prepare your environment and customize your chart by executing the `configure.sh` script and pass it the required parameters: 
+* Next, prepare your environment and customize your chart by executing the `configure.sh` script and pass it the following parameters: 
 
 | Parameter     | Description                                                                    |
 |---------------|--------------------------------------------------------------------------------|
-| `-p`          | REQUIRED: The password for the management `admin` user |
-| `-i`          | OPTIONAL: The Solace image reference in the docker container registry in the form `<DockerRepo>.<ImageName>:<releaseTag>` from [Step 3](#step-3-optional). The default is to use `solace/solace-pubsub-standard:latest`. NOTE: If providing a reference, the `<DockerRepo>.` is not required if using a local repo (e.g. when using MiniKube) |
+| `-p`          | REQUIRED for the first time: The password for the management `admin` user |
+| `-i`          | OPTIONAL: The Solace image reference in the docker container registry in the form `<DockerRepo>.<ImageName>:<releaseTag>` from [Step 3](#step-3-optional). The default is to use `solace/solace-pubsub-standard:latest`. NOTE: If providing a reference, the `<DockerRepo>.` is not required when using a local repo (e.g. when using MiniKube) |
 | `-c`          | OPTIONAL: The cloud environment you will be running in, current options are [aws\|gcp]. NOTE: if you are not using dynamic provisioned persistent disks, or, if you are running a local MiniKube environment, this option can be left out. |
 | `-v`          | OPTIONAL: The path to a `values.yaml` example/custom file to use. The default file is `values-examples/dev100-direct-noha.yaml` |
-| `-r`          | OPTIONAL: Restore Helm tooling, see section [Restoring Helm if not available](#restoring-helm-if-not-available ) |
+| No parameter | OPTIONAL: Restore Helm tooling, see section [Restoring Helm if not available](#restoring-helm-if-not-available ) |
 
 The location of the `configure.sh` script is in the `../scripts` directory, relative to the `solace` chart. Executing the configuration script will install the required version of the Helm tool if needed, as well as customize the `solace` Helm chart to your desired configuration.
 
@@ -258,14 +258,14 @@ To upgrade/modify the message broker cluster, make the required modifications to
 
 Before getting into the details of how to make changes to a deployment, it shall be noted that when using a new machine to access the deployment the Helm client may not be available or out of sync with the server. This can be the case when e.g. using cloud shell, which may be terminated any time.
 
-To restore Helm, run the configure command with the -r option:
+To restore Helm, run the configure command with no parameter provided:
 
 ```
 cd ~/workspace/solace-kubernetes-quickstart/solace
-../scripts/configure.sh -r
+../scripts/configure.sh
 ```
 
-Now Helm shall be available, e.g: `helm list` shall no longer return an error message.
+Now Helm shall be available on your client, e.g: `helm list` shall no longer return an error message.
 
 ### Upgrading the cluster
 

--- a/solace/templates/solaceConfigMap.yaml
+++ b/solace/templates/solaceConfigMap.yaml
@@ -228,7 +228,7 @@ data:
       results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
               -q "<rpc><show><redundancy><group/></redundancy></show></rpc>" \
               -c "/rpc-reply/rpc/show/redundancy/group-node/status[text() = \"Online\"]"`
-      nr_node_results=`echo ${role_results} |  xmllint -xpath "string(returnInfo/countSearchResult)" -`
+      nr_node_results=`echo ${results} |  xmllint -xpath "string(returnInfo/countSearchResult)" -`
       if [ $nr_node_results -ne 3 ]; then
         echo "`date` INFO: ${APP}-Not all nodes are online. Query results: ${nr_node_results}"
         exit 1

--- a/solace/values-examples/dev100-direct-noha.yaml
+++ b/solace/values-examples/dev100-direct-noha.yaml
@@ -26,6 +26,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -44,6 +50,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/dev100-persist-ha-nfs.yaml
+++ b/solace/values-examples/dev100-persist-ha-nfs.yaml
@@ -25,6 +25,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -43,6 +49,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/dev100-persist-ha-provisionPvc.yaml
+++ b/solace/values-examples/dev100-persist-ha-provisionPvc.yaml
@@ -25,6 +25,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -43,6 +49,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-direct-noha-existingVolume.yaml
+++ b/solace/values-examples/prod1k-direct-noha-existingVolume.yaml
@@ -27,6 +27,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -45,6 +51,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-direct-noha-localDirectory.yaml
+++ b/solace/values-examples/prod1k-direct-noha-localDirectory.yaml
@@ -26,6 +26,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -44,6 +50,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-direct-noha-provisionPvc.yaml
+++ b/solace/values-examples/prod1k-direct-noha-provisionPvc.yaml
@@ -26,6 +26,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -44,6 +50,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-direct-noha.yaml
+++ b/solace/values-examples/prod1k-direct-noha.yaml
@@ -26,6 +26,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -44,6 +50,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-persist-ha-nfs.yaml
+++ b/solace/values-examples/prod1k-persist-ha-nfs.yaml
@@ -25,6 +25,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -43,6 +49,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-persist-ha-provisionPvc.yaml
+++ b/solace/values-examples/prod1k-persist-ha-provisionPvc.yaml
@@ -25,6 +25,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -43,6 +49,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-persist-noha-existingVolume.yaml
+++ b/solace/values-examples/prod1k-persist-noha-existingVolume.yaml
@@ -26,6 +26,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -44,6 +50,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values-examples/prod1k-persist-noha-provisionPvc.yaml
+++ b/solace/values-examples/prod1k-persist-noha-provisionPvc.yaml
@@ -25,6 +25,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -43,6 +49,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP

--- a/solace/values.yaml
+++ b/solace/values.yaml
@@ -26,6 +26,12 @@ service:
     - port: 55555
       protocol: TCP
       name: smf
+    - port: 55003
+      protocol: TCP
+      name: smfcompr
+    - port: 55443
+      protocol: TCP
+      name: smftls
     - port: 943
       protocol: TCP
       name: semptls
@@ -44,6 +50,10 @@ service:
     - port: 8080
       protocol: TCP
     - port: 55555
+      protocol: TCP
+    - port: 55003
+      protocol: TCP
+    - port: 55443
       protocol: TCP
     - port: 60943
       protocol: TCP


### PR DESCRIPTION
- Updates to include smf compression and ssl ports
- Fix always hitting less than 3 nodes online at initial startup
- Restructured configure script: it can be used to change parameters
- Document alternative deployment method through template generation