### PR TITLE
Readiness check and other fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ script:
 - curl -sS -u admin:admin http://$url:8080/SEMP -d "<rpc><show><redundancy></redundancy></show></rpc>"
 - curl -sS -u admin:admin http://$url:8080/SEMP -d "<rpc><show><config-sync></config-sync></show></rpc>"
 - helm list
-- helm delete $(helm list | grep DEPLOYED | awk '{print $1}')
+- helm delete $(helm list | grep deployed | awk '{print $1}')
 - kubectl delete pvc --all
 - bash docs/helm-charts/create-chart-variants.sh; # Create chart variants
 - helm lint pubsubplus

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_install:
 - gcloud auth activate-service-account -q $(jq -r .client_email keyfile) --key-file=./keyfile
   --project  $(jq -r .project_id keyfile)
 - rm ./keyfile
-- export DESIRED_VERSION=v2.14.3; curl -sSL https://raw.githubusercontent.com/helm/helm/master/scripts/get
-  | bash
+- export DESIRED_VERSION=; curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+  | bash; helm version
 install: true
 script:
 - pwd
@@ -36,12 +36,12 @@ script:
   capable-stream-180018
 - popd
 - kubectl get statefulset,svc,pods,pvc,pv
-- kubectl -n kube-system create serviceaccount tiller
-- kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-- helm init --wait --service-account=tiller --upgrade
-- helm version
+- #kubectl -n kube-system create serviceaccount tiller
+- #kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+- #helm init --wait --service-account=tiller --upgrade
+- #helm version
 - helm lint pubsubplus
-- helm install --set solace.size=dev,solace.redundancy=true,solace.usernameAdminPassword=admin --name my-release pubsubplus
+- helm install my-release --set solace.size=dev,solace.redundancy=true,solace.usernameAdminPassword=admin pubsubplus
 - kubectl get statefulset,svc,pods,pvc,pv --show-labels
 - echo "Waiting for cluster to become active"
 - travis_wait 30 sleep 1800 &
@@ -69,15 +69,15 @@ script:
 - curl -sS -u admin:admin http://$url:8080/SEMP -d "<rpc><show><redundancy></redundancy></show></rpc>"
 - curl -sS -u admin:admin http://$url:8080/SEMP -d "<rpc><show><config-sync></config-sync></show></rpc>"
 - helm list
-- helm delete $(helm list | grep DEPLOYED | awk '{print $1}') --purge
+- helm delete $(helm list | grep DEPLOYED | awk '{print $1}')
 - kubectl delete pvc --all
 - bash docs/helm-charts/create-chart-variants.sh; # Create chart variants
 - helm lint pubsubplus
-- helm install pubsubplus --dry-run
+- helm install --generate-name pubsubplus --dry-run
 - helm lint pubsubplus-ha
-- helm install pubsubplus-ha --dry-run
+- helm install --generate-name pubsubplus-ha --dry-run
 - helm lint pubsubplus-dev
-- helm install pubsubplus-dev --dry-run
+- helm install --generate-name pubsubplus-dev --dry-run
 - # Publish to gh-pages and test
 - >
   if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The [Solace PubSub+ Platform](https://solace.com/products/platform/)'s [software
 
 This document provides a quick getting started guide to install a software event broker in various configurations onto a [Kubernetes](https://kubernetes.io/docs/home/) cluster. The recommended software event broker version is 9.4 or later.
 
-Detailed documentation is provided in the [Solace PubSub+ Software Event Broker on Kubernetes Documentation](docs/PubSubPlusK8SDeployment.md).
+*Detailed* *documentation* is provided in the [Solace PubSub+ Software Event Broker on Kubernetes Documentation](docs/PubSubPlusK8SDeployment.md).
 
 This quick start is intended mainly for development and demo purposes. Consult the [Deployment Considerations](https://github.com/SolaceProducts/pubsubplus-kubernetes-quickstart/blob/master/docs/PubSubPlusK8SDeployment.md#pubsub-event-broker-deployment-considerations) section of the Documentation when planning your deployment.
 

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -628,23 +628,32 @@ Use the external Public IP to access the deployment. If a port required for a pr
 
 ## Troubleshooting
 
+### General Kubernetes troubleshooting hints
+https://kubernetes.io/docs/tasks/debug-application-cluster/debug-application/
+
+### Checking the reason for failed resources
+
+Run `kubectl get statefulsets,services,pods,pvc,pv` to get an understanding of the state, then drill down to get more information on a failed resource to reveal  possible Kubernetes resourcing issues, e.g.:
+```sh
+kubectl describe pvc <pvc-name>
+```
+
 ### Viewing logs
 
-Detailed logs from the currently running container:
+Detailed logs from the currently running container in a pod:
 ```sh
-kubectl logs XXX-XXX-pubsubplus-0 -c solace  # use -f to follow live
+kubectl logs XXX-XXX-pubsubplus-0 -f  # use -f to follow live
 ```
 
-Detailed logs from the previously terminated container:
+It is also possible to get the logs from a previously terminated or failed container:
 ```sh
-kubectl logs XXX-XXX-pubsubplus-0 -c solace -p
+kubectl logs XXX-XXX-pubsubplus-0 -p
 ```
 
-Filter on bringup logs (helps with initial troubleshooting):
+Filtering on bringup logs (helps with initial troubleshooting):
 ```sh
-kubectl logs XXX-XXX-pubsubplus-0 -c solace | grep [.]sh
+kubectl logs XXX-XXX-pubsubplus-0 | grep [.]sh
 ```
-
 
 ### Viewing events
 
@@ -657,9 +666,6 @@ kubectl get events -w # use -w to watch live
 ```
 
 ### PubSub+ Software Event Broker troubleshooting
-
-#### General Kubernetes troubleshooting hints
-https://kubernetes.io/docs/tasks/debug-application-cluster/debug-application/
 
 #### Pods stuck in not enough resources
 
@@ -676,7 +682,10 @@ kubectl get storageclasses
 
 #### Pods stuck in CrashLoopBackoff, Failed or Not Ready
 
-Pods stuck in CrashLoopBackoff, or Failed, or Running but not Ready "active" state, usually indicate an issue at the container OS or the event broker process start. Try to delete and then recreate the deployment - if needed, remove related PVCs as they would mount volumes with existing, possibly outdated or incompatible database - and watch the [logs](#viewing-logs) and [events](#viewing-events) from the beginning. Look for ERROR messages preceded by information that may reveal the issue. Also try to check [logs from the previously terminated container](#viewing-logs).
+Pods stuck in CrashLoopBackoff, or Failed, or Running but not Ready "active" state, usually indicate an issue with available Kubernetes node resources or with the container OS or the event broker process start.
+
+* Try to understand the reason following earlier hints in this section.
+* Try to recreate the issue by deleting and then reinstalling the deployment - ensure to remove related PVCs if applicable as they would mount volumes with existing, possibly outdated or incompatible database - and watch the [logs](#viewing-logs) and [events](#viewing-events) from the beginning. Look for ERROR messages preceded by information that may reveal the issue.
 
 #### No Pods listed
 

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -228,7 +228,7 @@ The `service.ports` parameter defines the services exposed. It specifies the eve
 
 When using Helm to initiate a deployment, notes will be provided on the screen about how to obtain the service addresses and ports specific to your deployment - follow the "Services access" section of the notes. 
 
-A deployment is ready for service requests when there is a Solace pod that is running, `1/1` ready, and the pod's label is "active=true." The exposed `pubsubplus` service will forward traffic to that active event broker node. 
+A deployment is ready for service requests when there is a Solace pod that is running, `1/1` ready, and the pod's label is "active=true." The exposed `pubsubplus` service will forward traffic to that active event broker node. **Important**: service means here [Guaranteed Messaging level of  Quality-of-Service (QoS) of event messages persistence](//docs.solace.com/PubSub-Basics/Guaranteed-Messages.htm). Messaging traffic will not be forwarded if service level is degraded to [Direct Messages](//docs.solace.com/PubSub-Basics/Direct-Messages.htm) only.
 
 #### Using pod label "active" to identify the active event broker node
 

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -790,7 +790,7 @@ helm install my-release solacecharts/pubsubplus --set solace.size=dev,solace.red
 # Delete this deployment
 helm delete my-release
 # Reinstall deployment, assuming persistent storage. Notice the admin password specified
-helm install my-release solacecharts/pubsubplus --set solace.size=dev,solace.redundancy=true,,solace.usernameAdminPassword: jMzKoW39zz
+helm install my-release solacecharts/pubsubplus --set solace.size=dev,solace.redundancy=true,solace.usernameAdminPassword=jMzKoW39zz
 # Original deployment is now back up
 ```
 

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -350,9 +350,9 @@ Check your platform running the `kubectl get nodes` command from your command-li
 
 #### Install and setup the Helm package manager
 
-The event broker can be deployed using both Helm v2 (stable, legacy) and Helm v3 (new, recently released). Most deployments currently use Helm v2.
+The event broker can be deployed using both Helm v2 and Helm v3. Helm v3 is recommended as it offers better security and it is actively maintained.
 
-If `helm version` fails on your command-line client then this may involve installing Helm and/or if using Helm v2 (default for now) then also deploying/redeploying Tiller, its in-cluster operator.
+If `helm version` fails on your command-line client then this may involve installing Helm and/or if using Helm v2 then also deploying/redeploying Tiller, its in-cluster operator.
 
 ##### Helm v2
 
@@ -687,7 +687,7 @@ Use the `helm upgrade` command to upgrade/modify the event broker deployment: re
 
 Tip: to get the current value-overrides, check the `USER-SUPPLIED VALUES`:
 ```bash
-helm get my-release | sed '/^HOOKS/,$d'
+helm get values my-release
 ```
 
 For the next examples, assume a deployment has been created with some initial overrides for a develoment HA cluster:

--- a/pubsubplus/Chart.yaml
+++ b/pubsubplus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Deploy Solace PubSub+ Event Broker Singleton or HA redundancy group onto a Kubernetes Cluster
 name: pubsubplus
-version: 2.1.2
+version: 2.2.0
 icon: https://solaceproducts.github.io/pubsubplus-kubernetes-quickstart/images/PubSubPlus.png
 maintainers:
   - name: Solace Community Forum

--- a/pubsubplus/README.md
+++ b/pubsubplus/README.md
@@ -11,7 +11,7 @@ Detailed documentation is provided in the [Solace PubSub+ Software Event Broker 
 ## Prerequisites
 
 * Kubernetes 1.10 or later platform with adequate [CPU and memory](//github.com/SolaceProducts/pubsubplus-kubernetes-quickstart/blob/master/docs/PubSubPlusK8SDeployment.md#cpu-and-memory-requirements) and [storage resources](//github.com/SolaceProducts/pubsubplus-kubernetes-quickstart/blob/master/docs/PubSubPlusK8SDeployment.md#disk-storage) for the targeted scaling tier requirements
-* Helm package manager v2 or v3 client installed and configured with Tiller deployed if using Helm v2
+* Helm package manager v2 or v3 client installed and configured with Tiller deployed if using Helm v2. Helm v3 is recommended, examples in this document use v3.
 * If using a private Docker registry, load the PubSub+ Software Event Broker Docker image and for signed images create an image pull secret
 * With persistent storage enabled (see in [Configuration](#config-storageclass)):
   * Specify a storage class unless using a default storage class in your Kubernetes cluster
@@ -22,7 +22,7 @@ Also review additional [deployment considerations](//github.com/SolaceProducts/p
 
 ```bash
 helm repo add solacecharts https://solaceproducts.github.io/pubsubplus-kubernetes-quickstart/helm-charts
-helm install --name my-release solacecharts/pubsubplus
+helm install my-release solacecharts/pubsubplus
 ```
 
 ## Use a deployment
@@ -41,7 +41,7 @@ Refer to the detailed PubSub+ Kubernetes documentation for:
 ## Delete a deployment
 
 ```bash
-helm delete --purge my-release
+helm delete my-release
 kubectl get pvc | grep data-my-release
 # Delete any PVCs related to my-release
 ```
@@ -55,7 +55,7 @@ There are several ways to customize the deployment:
 
 - Override default values using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```bash
-helm install --name my-release \
+helm install my-release \
   --set solace.redundancy=true,solace.usernameAdminPassword=secretpassword \
   solacecharts/pubsubplus
 ```
@@ -83,7 +83,7 @@ For more ways to override default chart values, refer to [Customizing the Helm C
 | `solace.usernameAdminPassword` | The password for the "admin" management user. Will autogenerate it if not provided. **Important:** refer to the the information from `helm status` how to retrieve it and use it for `helm upgrade`. | Undefined, meaning autogenerate |
 | `solace.timezone`              | Timezone setting for the PubSub+ container. Valid values are tz database time zone names.               | Undefined, default is UTC |
 | `image.repository`             | The docker repo name and path to the Solace Docker image                                                | `solace/solace-pubsub-standard` from public DockerHub   |
-| `image.tag`                    | The Solace Docker image tag. It is recommended to specify an explicit tag for production use            | `latest`                                                |
+| `image.tag`                    | The Solace Docker image tag. It is recommended to specify an explicit tag for production use For possible tags, refer to the [Solace Docker Hub repo](https://hub.docker.com/r/solace/solace-pubsub-standard/tags) | `latest`                                                |
 | `image.pullPolicy`             | Image pull policy                                                                                       | `IfNotPresent`                                          |
 | `image.pullSecretName`         | Name of the ImagePullSecret to be used with the Docker registry                                         | Undefined, meaning no ImagePullSecret used                |
 | `securityContext.enabled`      | `true` enables to using defined `fsGroup` and `runAsUser`. Set to `false` if `fsGroup` and `runAsUser` conflict with PodSecurityPolicy or Openshift SCC settings. | `true` meaning `fsGroup` and `runAsUser` used |

--- a/pubsubplus/templates/solaceConfigMap.yaml
+++ b/pubsubplus/templates/solaceConfigMap.yaml
@@ -306,9 +306,8 @@ data:
     fi
     # Record current version in lastversion_file
     readlink /usr/sw/loads/currentload > ${lastversion_file}
-
+    # For monitor node just check for 3 online nodes in group; active label will never be set
     if [ "${node_ordinal}" = "2" ]; then
-      # For monitor node just check for 3 online nodes in group; active label will always be "false"
       role_results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
               -q "<rpc><show><redundancy><group/></redundancy></show></rpc>" \
               -c "/rpc-reply/rpc/show/redundancy/group-node/status[text() = \"Online\"]"`
@@ -326,25 +325,24 @@ data:
         exit 1
       fi
     fi # End Monitor Node
-
+    # For Primary or Backup nodes set both service readiness (active label) and k8s readiness (exit return value)
     health_result=`curl -s -o /dev/null -w "%{http_code}"  http://localhost:5550/health-check/guaranteed-active`
-    
     case "${health_result}" in
       "200")
-        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-Message Router is Active and Healthy (200)"; fi
+        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-HA Message Router health check reported 200, message spool is up"; fi
         set_label "active" "true" $state_file
         exit 0
         ;;
       "503")
-        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-Message Router is Healthy but not Active, further check required (503)"; fi
+        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-HA Message Router health check reported 503"; fi
         set_label "active" "false" $state_file
+        # Further check is required to determine readiness
         ;;
-      "")
-        echo "`date` WARN: ${APP}-Unable to determine config role, failing readiness check"
+      *)
+        echo "`date` WARN: ${APP}-HA Message Router health check reported unexpected ${health_result}"
         set_label "active" "false" $state_file
         exit 1
     esac
-
     # Checking if Message Router is Standby
     case "${node_ordinal}" in
       "0")
@@ -359,48 +357,35 @@ data:
             -v "/rpc-reply/rpc/show/redundancy/virtual-routers/${config_role}/status/activity[text()]"`
     local_activity=`echo ${online_results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
     case "${local_activity}" in
-      "Local Active")
-        # Redundancy is up and node is locally Active"
-        # Set active label to "true"
-        set_label "active" "true" $state_file
-        # Pass readiness check
-        echo "`date` INFO: ${APP}-Had 503 but passing readiness check because SEMP call worked and got Local Active"
-        exit 0
-        ;;
       "Mate Active")
         # Redundancy is up and node is mate Active"
-        # Set active label to "false"
-        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-This broker node is Mate Active"; fi
-        set_label "active" "false" $state_file
         # Pass readiness check
         exit 0
         ;;
       *)
         echo "`date` WARN: ${APP}-Redundancy not up or not responding, failing readiness check. Local activity state is: ${local_activity}"
-        # Set active label to "false"
-        set_label "active" "false" $state_file
-        # Fail readiness check
         exit 1
         ;;
     esac
 {{- else }}
     # nonHA config
     health_result=`curl -s -o /dev/null -w "%{http_code}"  http://localhost:5550/health-check/guaranteed-active`
-    
     case "${health_result}" in
       "200")
-        echo "`date` INFO: ${APP}-nonHA Message Router is Active and Healthy"
+        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-nonHA Message Router health check reported 200, message spool is up"; fi
         set_label "active" "true" $state_file
         exit 0
         ;;
       "503")
-        echo "`date` INFO: ${APP}-nonHA Message Router message spool is down"
+        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-nonHA Message Router health check reported 503, message spool is down"; fi
         set_label "active" "false" $state_file
+        # Fail readiness check
         exit 1
         ;;
-      "")
-        echo "`date` WARN: ${APP}-Unable to determine config role, failing readiness check"
+      *)
+        echo "`date` WARN: ${APP}-nonHA Message Router health check reported ${health_result}"
         set_label "active" "false" $state_file
+        # Fail readiness check
         exit 1
     esac
 {{- end }}

--- a/pubsubplus/templates/solaceConfigMap.yaml
+++ b/pubsubplus/templates/solaceConfigMap.yaml
@@ -72,7 +72,7 @@ data:
       esac
 {{- end }}
 
-  config-sync-check.sh: |-
+  setup-config-sync.sh: |-
       #!/bin/bash
 {{- if .Values.solace.redundancy }}
       APP=`basename "$0"`
@@ -231,7 +231,8 @@ data:
 
   readiness_check.sh: |-
     #!/bin/bash
-    LOG_FILE=/var/lib/solace/jail/logs/k8s_readiness_check.log
+    LOG_FILE=/usr/sw/var/k8s_readiness_check.log # STDOUT/STDERR goes to k8s event logs but gets cleaned out eventually. This will also persist it.
+    tail -n 1000 ${LOG_FILE} > ${LOG_FILE}.tmp; mv -f ${LOG_FILE}.tmp ${LOG_FILE} || :  # Limit logs size
     exec > >(tee -a ${LOG_FILE}) 2>&1
 
     # Function to set Kubernetes metadata labels
@@ -239,10 +240,10 @@ data:
       #Prevent overdriving Kubernetes infra, don't set activity state to same as previous state
       previous_state=`cat $3`
       if [ "${2}" = "${previous_state}" ]; then
-        echo "`date` INFO: ${APP}-Current and Previous state match (${2}), not updating label"
+        #echo "`date` INFO: ${APP}-Current and Previous state match (${2}), not updating label"
         :
       else
-        echo "`date` INFO: ${APP}-Trying to update label from `cat ${3}` to ${2}"
+        echo "`date` INFO: ${APP}-Updating label from `cat ${3}` to ${2}"
         echo ${2} > ${3}
         echo "[{\"op\": \"add\", \"path\": \"/metadata/labels/${1}\", \"value\": \"${2}\" }]" > /tmp/patch_label.json
         K8S=https://kubernetes.default.svc.cluster.local:$KUBERNETES_SERVICE_PORT
@@ -264,7 +265,7 @@ data:
         fi
       fi
     }
-    # note that there are no re-tries here, if check fails the return not ready.
+    # note that there are no re-tries here, if check fails then return not ready.
     APP=`basename "$0"`
     state_file=/tmp/activity_state
     if [ ! -f ${state_file} ]; then  # State file not found, creating
@@ -277,39 +278,20 @@ data:
     node_ordinal=${host_array[-1]}
     password=`cat /mnt/disks/secrets/username_admin_password`
 
-    # For upgrade purposes, ensure redundancy is up only when the pod is started
-    redundacycheck_file=/tmp/redundacycheck
-    if [ ! -f ${redundacycheck_file} ]; then
-      echo "`date` INFO: ${APP}-redundacycheck_file didn't exist, running extended checks for startup only"
-      # First check all nodes are online
+    # For upgrade purposes, additional checks are required for readiness state when the pod has been started
+    # This is an upgrade if the lastversion_file exists and contents differ from /usr/sw/loads/currentload
+    lastversion_file=/usr/sw/var/lastBrokerVersionBeforeReboot
+    if [ -f ${lastversion_file} ] && [[ $(cat ${lastversion_file}) != $(readlink /usr/sw/loads/currentload) ]] ; then
+      echo "`date` INFO: ${APP}-Upgrade detected, running additional checks..."
+      # Check redundancy
       results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
-              -q "<rpc><show><redundancy><group/></redundancy></show></rpc>" \
-              -c "/rpc-reply/rpc/show/redundancy/group-node/status[text() = \"Online\"]"`
-      if [[ ${results} != *"<errorInfo></errorInfo>"* ]]; then
-        errorinfo=`echo ${results} | xmllint -xpath "string(returnInfo/errorInfo)" -` || errorinfo=
-        echo "`date` INFO: ${APP}-Waiting for valid server status response, got ${errorinfo}"
+              -q "<rpc><show><redundancy/></show></rpc>" \
+              -v "/rpc-reply/rpc/show/redundancy/redundancy-status"`
+      redundancystatus_results=`echo ${results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
+      if [ "${redundancystatus_results}" != "Up" ]; then
+        echo "`date` INFO: ${APP}-Redundancy state is not yet up."
         exit 1
       fi
-      nr_node_results=`echo ${results} |  xmllint -xpath "string(returnInfo/countSearchResult)" -`
-      if [ "$nr_node_results" -ne "3" ]; then
-        echo "`date` INFO: ${APP}-Waiting for all 3 nodes online, got ${nr_node_results}"
-        exit 1
-      fi
-      # Then for each node determine the ip address and check redundancy. Note: id starts here from 1 and not 0.
-      for id in 1 2 3; do
-        results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
-                -q "<rpc><show><redundancy><group/></redundancy></show></rpc>" \
-                -v "//ip-address[$id]"`
-        node_ip_address=`echo ${results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
-        results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://$node_ip_address:8080/SEMP \
-                -q "<rpc><show><redundancy/></show></rpc>" \
-                -v "/rpc-reply/rpc/show/redundancy/redundancy-status"`
-        redundancystatus_results=`echo ${results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
-        if [ "${redundancystatus_results}" != "Up" ]; then
-          echo "`date` INFO: ${APP}-Redundancy state is not yet up."
-          exit 1
-        fi
-      done
       # Additionally check config-sync status for non-monitoring nodes
       if [ "${node_ordinal}" != "2" ]; then
         results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
@@ -321,26 +303,10 @@ data:
           exit 1
         fi
       fi
-      # Then for each node check that they report 3 Consul voters.
-      for id in 1 2 3; do
-        results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
-                -q "<rpc><show><redundancy><group/></redundancy></show></rpc>" \
-                -v "//ip-address[$id]"`
-        node_ip_address=`echo ${results} | xmllint -xpath "string(returnInfo/valueSearchResult)" -`
-        nr_voter_results=`curl --unix-socket /var/run/solace/consul -s http://$node_ip_address:8500/v1/operator/raft/configuration  || echo {} | python -m json.tool | grep Voter | grep true | wc -l`
-        if [ $nr_voter_results -ne 3 ]; then
-          # For backwards compatibility - will revise.
-          nr_voter_results=`curl --unix-socket /var/run/consul -s http://$node_ip_address:8500/v1/operator/raft/configuration  | python -m json.tool | grep Voter | grep true | wc -l`
-          if [ $nr_voter_results -ne 3 ]; then
-            echo "`date` INFO: ${APP}-Waiting for all 3 Consul voters to be present for node $node_ip_address, got ${nr_voter_results}"
-            exit 1
-          fi
-        fi
-      done
-      # Creating marker - important that after initial startup pod keeps being ready to serve traffic during failover while redundancy is down
-      echo "true" > ${redundacycheck_file}
     fi
-    
+    # Record current version in lastversion_file
+    readlink /usr/sw/loads/currentload > ${lastversion_file}
+
     if [ "${node_ordinal}" = "2" ]; then
       # For monitor node just check for 3 online nodes in group; active label will always be "false"
       role_results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
@@ -353,7 +319,7 @@ data:
       fi
       nodes_online=`echo ${role_results} |  xmllint -xpath "string(returnInfo/countSearchResult)" -`
       if [ "$nodes_online" -eq "3" ]; then
-        echo "`date` INFO: ${APP}-Monitor node is redundancy ready"
+        #echo "`date` INFO: ${APP}-Monitor node is redundancy ready"
         exit 0
       else
         echo "`date` INFO: ${APP}-Monitor node is not redundancy ready, ${nodes_online} of 3 nodes online"
@@ -365,20 +331,20 @@ data:
     
     case "${health_result}" in
       "200")
-        echo "`date` INFO: ${APP}-Message Router is Active and Healthy (200)"
+        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-Message Router is Active and Healthy (200)"; fi
         set_label "active" "true" $state_file
         exit 0
         ;;
       "503")
+        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-Message Router is Healthy but not Active, further check required (503)"; fi
         set_label "active" "false" $state_file
-        echo "`date` INFO: ${APP}-Message Router is Healthy but not Active, further check required (503)"
         ;;
       "")
         echo "`date` WARN: ${APP}-Unable to determine config role, failing readiness check"
         set_label "active" "false" $state_file
         exit 1
     esac
-     
+
     # Checking if Message Router is Standby
     case "${node_ordinal}" in
       "0")
@@ -404,9 +370,9 @@ data:
       "Mate Active")
         # Redundancy is up and node is mate Active"
         # Set active label to "false"
+        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-This broker node is Mate Active"; fi
         set_label "active" "false" $state_file
         # Pass readiness check
-        echo "`date` INFO: ${APP}-Had 503 but this is Mate Active so passing readiness check"
         exit 0
         ;;
       *)

--- a/pubsubplus/templates/solaceConfigMap.yaml
+++ b/pubsubplus/templates/solaceConfigMap.yaml
@@ -231,15 +231,18 @@ data:
 
   readiness_check.sh: |-
     #!/bin/bash
+    LOG_FILE=/var/lib/solace/jail/logs/k8s_readiness_check.log
+    exec > >(tee -a ${LOG_FILE}) 2>&1
 
     # Function to set Kubernetes metadata labels
     set_label () {
       #Prevent overdriving Kubernetes infra, don't set activity state to same as previous state
       previous_state=`cat $3`
       if [ "${2}" = "${previous_state}" ]; then
-        #echo "`date` INFO: ${APP}-Current and Previous state match, not updating label"
+        echo "`date` INFO: ${APP}-Current and Previous state match (${2}), not updating label"
         :
       else
+        echo "`date` INFO: ${APP}-Trying to update label from `cat ${3}` to ${2}"
         echo ${2} > ${3}
         echo "[{\"op\": \"add\", \"path\": \"/metadata/labels/${1}\", \"value\": \"${2}\" }]" > /tmp/patch_label.json
         K8S=https://kubernetes.default.svc.cluster.local:$KUBERNETES_SERVICE_PORT
@@ -257,6 +260,7 @@ data:
             echo "`date` ERROR: ${APP}-Unable to update pod label, check access from pod to K8s API or RBAC authorization" >&2
             exit 1
           fi
+          echo "`date` INFO: ${APP}-Failed to update label from ${3} to ${2}, retrying"
         fi
       fi
     }
@@ -276,6 +280,7 @@ data:
     # For upgrade purposes, ensure redundancy is up only when the pod is started
     redundacycheck_file=/tmp/redundacycheck
     if [ ! -f ${redundacycheck_file} ]; then
+      echo "`date` INFO: ${APP}-redundacycheck_file didn't exist, running extended checks for startup only"
       # First check all nodes are online
       results=`/mnt/disks/solace/semp_query.sh -n admin -p ${password} -u http://localhost:8080/SEMP \
               -q "<rpc><show><redundancy><group/></redundancy></show></rpc>" \
@@ -360,13 +365,13 @@ data:
     
     case "${health_result}" in
       "200")
-        echo "`date` INFO: ${APP}-Message Router is Active and Healthy"
+        echo "`date` INFO: ${APP}-Message Router is Active and Healthy (200)"
         set_label "active" "true" $state_file
         exit 0
         ;;
       "503")
         set_label "active" "false" $state_file
-        echo "`date` INFO: ${APP}-Message Router is Healthy but not Active, further check required"
+        echo "`date` INFO: ${APP}-Message Router is Healthy but not Active, further check required (503)"
         ;;
       "")
         echo "`date` WARN: ${APP}-Unable to determine config role, failing readiness check"
@@ -393,6 +398,7 @@ data:
         # Set active label to "true"
         set_label "active" "true" $state_file
         # Pass readiness check
+        echo "`date` INFO: ${APP}-Had 503 but passing readiness check because SEMP call worked and got Local Active"
         exit 0
         ;;
       "Mate Active")
@@ -400,6 +406,7 @@ data:
         # Set active label to "false"
         set_label "active" "false" $state_file
         # Pass readiness check
+        echo "`date` INFO: ${APP}-Had 503 but this is Mate Active so passing readiness check"
         exit 0
         ;;
       *)
@@ -431,7 +438,6 @@ data:
         exit 1
     esac
 {{- end }}
-
   semp_query.sh: |-
       #!/bin/bash
       APP=`basename "$0"`

--- a/pubsubplus/templates/solaceConfigMap.yaml
+++ b/pubsubplus/templates/solaceConfigMap.yaml
@@ -224,7 +224,7 @@ data:
           exit 1
         fi
       fi # if not monitor
-      echo "`date` INFO: ${APP}-Solace message broker bringup is complete for this node."
+      echo "`date` INFO: ${APP}-Solace Event Broker bringup is complete for this node."
 {{- end }}
       exit 0
 
@@ -329,21 +329,21 @@ data:
     health_result=`curl -s -o /dev/null -w "%{http_code}"  http://localhost:5550/health-check/guaranteed-active`
     case "${health_result}" in
       "200")
-        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-HA Message Router health check reported 200, message spool is up"; fi
+        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-HA Event Broker health check reported 200, message spool is up"; fi
         set_label "active" "true" $state_file
         exit 0
         ;;
       "503")
-        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-HA Message Router health check reported 503"; fi
+        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-HA Event Broker health check reported 503"; fi
         set_label "active" "false" $state_file
         # Further check is required to determine readiness
         ;;
       *)
-        echo "`date` WARN: ${APP}-HA Message Router health check reported unexpected ${health_result}"
+        echo "`date` WARN: ${APP}-HA Event Broker health check reported unexpected ${health_result}"
         set_label "active" "false" $state_file
         exit 1
     esac
-    # Checking if Message Router is Standby
+    # At this point analyzing readiness after health check returned 503 - checking if Event Broker is Standby
     case "${node_ordinal}" in
       "0")
         config_role="primary"
@@ -363,7 +363,7 @@ data:
         exit 0
         ;;
       *)
-        echo "`date` WARN: ${APP}-Redundancy not up or not responding, failing readiness check. Local activity state is: ${local_activity}"
+        echo "`date` WARN: ${APP}-Health check returned 503 and local activity state is: ${local_activity}, failing readiness check."
         exit 1
         ;;
     esac
@@ -372,18 +372,18 @@ data:
     health_result=`curl -s -o /dev/null -w "%{http_code}"  http://localhost:5550/health-check/guaranteed-active`
     case "${health_result}" in
       "200")
-        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-nonHA Message Router health check reported 200, message spool is up"; fi
+        if [[ $(cat $state_file) = "false" ]]; then echo "`date` INFO: ${APP}-nonHA Event Broker health check reported 200, message spool is up"; fi
         set_label "active" "true" $state_file
         exit 0
         ;;
       "503")
-        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-nonHA Message Router health check reported 503, message spool is down"; fi
+        if [[ $(cat $state_file) = "true" ]]; then echo "`date` INFO: ${APP}-nonHA Event Broker health check reported 503, message spool is down"; fi
         set_label "active" "false" $state_file
         # Fail readiness check
         exit 1
         ;;
       *)
-        echo "`date` WARN: ${APP}-nonHA Message Router health check reported ${health_result}"
+        echo "`date` WARN: ${APP}-nonHA Event Broker health check reported ${health_result}"
         set_label "active" "false" $state_file
         # Fail readiness check
         exit 1

--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -120,7 +120,7 @@ spec:
            source /mnt/disks/solace/init.sh
            # not using postinstall hooks because of order dependencies
            # launch config check - readiness check script will be launched by readinessProbe
-           nohup /mnt/disks/solace/config-sync-check.sh &
+           nohup /mnt/disks/solace/setup-config-sync.sh &
            /usr/sbin/boot.sh
         lifecycle:
           preStop:
@@ -155,12 +155,15 @@ spec:
         - name: data
           mountPath: /var/lib/solace/diags
           subPath: diags
-        {{- if and (not .Values.storage.slow) (not .Values.storage.nfs) }}
+{{- if (not .Values.storage.slow) }}
         # only mount when not using slow storage
         - name: data
           mountPath: /usr/sw/internalSpool/softAdb
           subPath: softAdb
-        {{- end }}
+{{- else }}
+        - name: soft-adb-ephemeral
+          mountPath: /usr/sw/internalSpool/softAdb
+{{- end }}
         ports:
         {{- range $item := .Values.service.ports }}
         - containerPort: {{ $item.containerPort }}
@@ -178,6 +181,10 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
+{{- if .Values.storage.slow }}
+        - name: soft-adb-ephemeral
+          emptyDir: {}
+{{- end }}
 {{- if and (.Values.storage) (not .Values.storage.persistent) }}
         - name: data
           emptyDir: {}
@@ -187,6 +194,7 @@ spec:
 {{ tpl . $ | indent 10 }}
           {{- end }}
 {{- else }}
+
   # This is the default way to acquire volume for the data mount
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
Suggested changelist:
* Addressed:
   - When shut down message-spool on the Primary active label seems to be changing periodically and FOREVER
   - Readiness check passes even if msg-backbone is shutdown
   - Readiness_check.sh in pubsubplus-kubernetes-quickstart incorrectly detects pod readiness after upgrade
* Added logging of k8s readiness check
* Updated documentation and tests to use Helm v3 now
* Improved softAdb behavior in case of NFS
* Additional documentation to increase awareness of auto-generated password
* Documentation enhancements
* Updated chart version to 2.2.0