### PR TITLE
Adding ownership file

### DIFF
--- a/helm-charts/artifacthub-repo.yml
+++ b/helm-charts/artifacthub-repo.yml
@@ -1,0 +1,16 @@
+# Artifact Hub repository metadata file
+#
+repositoryID:
+owners:
+  - name: bczoma
+    email: balazs.czoma@solace.com
+  - name: juddrobertson
+    email: judd.robertson@solace.com
+  - name: KenBarr
+    email: ken.barr@solace.com
+  - name: paul-kondrat
+    email: paul.kondrat@solace.com
+  - name: PhilippeKhalife
+    email: philippe.khalife@solace.com
+  - name: RagnarPaulson
+    email: ragnar.paulson@solace.com


### PR DESCRIPTION
Required to make the Solace charts official in Artifact Hub