### PR TITLE
Fix bug #112 preventing setting annotation on service

### DIFF
--- a/pubsubplus/values.schema.json
+++ b/pubsubplus/values.schema.json
@@ -43,7 +43,7 @@
             "type": "object",
             "properties": {
                 "annotations": {
-                    "type": "string"
+                    "type": "object"
                 },
                 "ports": {
                     "type": "array",

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -86,7 +86,8 @@ service:
   type: LoadBalancer
 
   # service.annotations allows to add provider-specific service annotations, see example below
-  # annotations: 'cloud.google.com/load-balancer-type: "internal"'
+  # annotations:
+  #   cloud.google.com/load-balancer-type: "internal"
 
   # List here all ports to be exposed as external service.
   #    "containerPorts" (from the PubSub+ container) will be exposed as external "servicePorts",


### PR DESCRIPTION
This change fixes bug #112 

Not sure about the origin, but I have tested this locally and it deploys the chart as expeted with internal loadbalancer on AKS.