### PR TITLE
fix: make probes configurable

### DIFF
--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -97,16 +97,9 @@ spec:
             memory: 52581Mi
 {{- end }}
         livenessProbe:
-          tcpSocket:
-            port: 8080
-          initialDelaySeconds: 300
-          timeoutSeconds: 5
+          {{- toYaml .Values.probes.liveness | nindent 10 }}
         readinessProbe:
-          initialDelaySeconds: 30
-          periodSeconds: 5
-          exec:
-            command:
-            - /mnt/disks/solace/readiness_check.sh
+          {{- toYaml .Values.probes.readiness | nindent 10 }}
         securityContext:
           privileged: false
 {{- if semverCompare "<9.4" (default "9.4" (regexFind "\\d+\\.\\d+" .Values.image.tag)) }}

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -220,3 +220,16 @@ storage:
   #  if undefined or set to false, the legacy behavior is to individually mount storage-elements in subdirectories.
   #  Note: legacy mount still works for broker version 9.12 and later but may be deprecated in the future.
   # useStorageGroup: true
+
+probes:
+  readiness:
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    exec:
+      command:
+      - /mnt/disks/solace/readiness_check.sh
+  liveness:
+    tcpSocket:
+      port: 8080
+    initialDelaySeconds: 300
+    timeoutSeconds: 5


### PR DESCRIPTION
this change gives the user the option to overwrite values for probes for example

```
helm template . --set probes.readiness.timeout=5s -s templates/solaceStatefulSet.yaml | grep -A 6 "readinessProbe:"
        readinessProbe:
          exec:
            command:
            - /mnt/disks/solace/readiness_check.sh
          initialDelaySeconds: 30
          periodSeconds: 5
          timeout: 5s
```

closes #137 

