### PR TITLE
ci(DATAGO-131317): fix: add packages: read for GHCR image pull

### DIFF
--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -16,6 +16,7 @@ permissions:
   checks: write         # For FOSSA status checks
   statuses: write       # For FOSSA commit status
   packages: read
+  id-token: write       # required by sca-scan-and-guard reusable workflow declaration
 
 jobs:
   fossa_scan:

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -1,4 +1,29 @@
 name: FOSSA Manual Scan
 
 on:
-  workflow_dispa
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to scan (leave empty for current branch)'
+        required: false
+        type: string
+
+permissions:
+  contents: read        # For checkout
+  pull-requests: write  # For PR comments
+  actions: read         # For sca-scan-and-guard
+  issues: write         # For issue comments
+  checks: write         # For FOSSA status checks
+  statuses: write       # For FOSSA commit status
+  packages: read        # required to pull ghcr.io image in fossa-guard composite action
+
+jobs:
+  fossa_scan:
+    name: FOSSA Scan
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    with:
+      git_ref: ${{ inputs.branch || github.ref_name }}
+      use_vault: false
+      config_file: '.github/workflow-config.json'
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -1,30 +1,4 @@
 name: FOSSA Manual Scan
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to scan (leave empty for current branch)'
-        required: false
-        type: string
-
-permissions:
-  contents: read        # For checkout
-  pull-requests: write  # For PR comments
-  actions: read         # For sca-scan-and-guard
-  issues: write         # For issue comments
-  checks: write         # For FOSSA status checks
-  statuses: write       # For FOSSA commit status
-  packages: read
-  id-token: write       # required by sca-scan-and-guard reusable workflow declaration
-
-jobs:
-  fossa_scan:
-    name: FOSSA Scan
-    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
-    with:
-      git_ref: ${{ inputs.branch || github.ref_name }}
-      use_vault: false
-      config_file: '.github/workflow-config.json'
-    secrets:
-      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+  workflow_dispa

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -15,6 +15,7 @@ permissions:
   issues: write         # For issue comments
   checks: write         # For FOSSA status checks
   statuses: write       # For FOSSA commit status
+  packages: read
 
 jobs:
   fossa_scan:


### PR DESCRIPTION
## Summary
Adds `packages: read` permission to workflow file(s).

## Context
An upcoming change in `solace-public-workflows` updates the composite actions
(`fossa-guard`, `cicd-helper`, `generate-fossa-report`) to pull the `maas-build-actions`
container image from GHCR using explicit `docker login` + `docker run`. Pulling from GHCR
requires the calling workflow's token to have at least `packages: read` — without it,
`docker login` returns a 403 and the job fails.