### PR TITLE
[Bucket F] Add FOSSA SCA scanning on merge to master

### DIFF
--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -42,7 +42,7 @@ jobs:
           ddb_sort_key: repository
           ddb_item_to_be_added: |
             {
-              "squad": "ebp",
+              "squad": "temp",
               "repository": "${{ github.event.repository.name }}",
               "dev": {
                 "sha": "${{ github.sha }}",

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -1,0 +1,51 @@
+name: SCA Scan on merge to main
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+  actions: read
+  statuses: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  sca_scan:
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+  update_manifest:
+    needs: sca_scan
+    if: needs.sca_scan.result == 'success' && github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+          aws-region: us-east-1
+
+      - name: Update solace-cloud-manifest
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: add_item_from_json_to_dynamodb_table
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_sort_key: repository
+          ddb_item_to_be_added: |
+            {
+              "squad": "ebp",
+              "repository": "${{ github.event.repository.name }}",
+              "dev": {
+                "sha": "${{ github.sha }}",
+                "version": "${{ github.ref_name }}"
+              }
+            }

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -42,7 +42,7 @@ jobs:
           ddb_sort_key: repository
           ddb_item_to_be_added: |
             {
-              "squad": "temp",
+              "squad": "launchpad",
               "repository": "${{ github.event.repository.name }}",
               "dev": {
                 "sha": "${{ github.sha }}",

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -42,7 +42,7 @@ jobs:
           ddb_sort_key: repository
           ddb_item_to_be_added: |
             {
-              "squad": "launchpad",
+              "squad": "launch-pad",
               "repository": "${{ github.event.repository.name }}",
               "dev": {
                 "sha": "${{ github.sha }}",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sca-scan-and-guard.yml` to run FOSSA scan on push to `master` and record the result in `solace-cloud-manifest` DynamoDB table
- Existing `.fossa.yml` and `.github/workflow-config.json` (BLOCK mode) are left untouched

## Part of
DATAGO-142436 — FOSSA SCA guardian onboarding

## Test plan
- [ ] Merge triggers `SCA Scan on merge to main` workflow
- [ ] `sca_scan` job completes (config-driven BLOCK mode from existing `workflow-config.json`)
- [ ] `update_manifest` job writes entry to `solace-cloud-manifest` DynamoDB table (pending DATAGO-142435 OIDC trust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)