### PR TITLE
Fix: Publish Helm Charts job silently skips on every master push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -518,13 +518,14 @@ jobs:
   publish:
     name: Publish Helm Charts
     needs: [fossa_scan, build_test, helm_template_tests]
-    if: |
+    if: >-
+      ${{ always() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/master' &&
       github.repository_owner == 'SolaceProducts' &&
       (needs.fossa_scan.result == 'success' || needs.fossa_scan.result == 'skipped') &&
       needs.build_test.result == 'success' &&
-      needs.helm_template_tests.result == 'success'
+      needs.helm_template_tests.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

The `Publish Helm Charts` job has **skipped on every push to `master`** since it was introduced in #165 — it has never actually published to `gh-pages`. This isn't tied to any single run; e.g. the #165 merge run itself was a fresh attempt with `FOSSA=success`, `Build & Test=success`, and `Helm Template Tests=success`, yet `publish` still skipped.

## Root cause

The `publish` job's `if` condition had **no status function** (`always()` / `success()`):

```yaml
if: |
  github.event_name == 'push' && ... &&
  needs.build_test.result == 'success' &&
  needs.helm_template_tests.result == 'success'
```

Without a status function, GitHub applies an implicit `success()` gate across the job's `needs` graph. Both `fossa_scan` and `build_test` depend on `check_permissions`, which is intentionally **skipped** on normal runs (it only runs when `inputs.skip_fossa` is set). That skipped ancestor causes the implicit gate to short-circuit and skip `publish` — before the explicit clauses are ever considered.

Notably, the sibling jobs `fossa_scan` and `build_test` already work around this exact issue with `if: ${{ always() && ... }}`; `publish` was just missing the same treatment.

## Fix

Prepend `always() &&` so the explicit `needs.*.result == 'success'` checks (which already enforce "only publish on green") are actually evaluated. This is safe:

- PRs / non-master pushes are still blocked by `github.event_name == 'push' && github.ref == 'refs/heads/master'`.
- A failed or cancelled `build_test` / `helm_template_tests` still blocks publish via the explicit `result == 'success'` checks.

This mirrors the pattern already used by `fossa_scan` and `build_test` in this same workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
